### PR TITLE
Update wave play

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -381,7 +381,7 @@ pub fn addPlay(
         \\
         \\    const wave = try user_module.{s}(allocator);
         \\    defer wave.deinit();
-        \\    try wave.play(allocator);
+        \\    try wave.play();
         \\}}
         \\
     , .{wave.create_wave_options.func_name});

--- a/examples/06-advanced/runtime-play/src/main.zig
+++ b/examples/06-advanced/runtime-play/src/main.zig
@@ -23,5 +23,5 @@ pub fn main() !void {
         .channels = 1,
     });
 
-    try wave.play(allocator);
+    try wave.play();
 }

--- a/src/wave.zig
+++ b/src/wave.zig
@@ -564,10 +564,9 @@ pub fn inner(comptime T: type) type {
         ///
         /// ## Errors
         /// Returns errors from the audio engine initialization or playback
-        pub fn play(
-            self: Self,
-            allocator: std.mem.Allocator,
-        ) anyerror!void {
+        pub fn play(self: Self) anyerror!void {
+            const allocator = self.allocator;
+
             zaudio.init(allocator);
             defer zaudio.deinit();
 


### PR DESCRIPTION
- To remove `allocator` argument from `Wave(T).play` function