### PR TITLE
Bump up to 0.20.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .lightmix,
-    .version = "0.19.1",
+    .version = "0.20.0",
     .fingerprint = 0xe48269dbca8904a,
     .minimum_zig_version = "0.15.2",
 


### PR DESCRIPTION
- To Bump up lightmix version from 0.19.1 to 0.20.0 because of #90 