### PR TITLE
Delete allocator from Wave(T).play function's docstring

### DIFF
--- a/src/wave.zig
+++ b/src/wave.zig
@@ -560,7 +560,6 @@ pub fn inner(comptime T: type) type {
         ///
         /// ## Parameters
         /// - `self`: The wave to play
-        /// - `allocator`: Memory allocator used for the intermediate f32 sample buffer
         ///
         /// ## Errors
         /// Returns errors from the audio engine initialization or playback


### PR DESCRIPTION
- To fix docs comments about `Wave(T).play()` function
  - It is caused by #90 changes