### PR TITLE
fix(Wave(T)): Failed to run `play()` in Windows platform

### DIFF
--- a/src/wave.zig
+++ b/src/wave.zig
@@ -579,7 +579,7 @@ pub fn inner(comptime T: type) type {
                 samples[i] = @as(f32, @floatCast(orig_sample));
             }
 
-            var buffer_config = zaudio.AudioBuffer.Config.init(.float32, self.channels, samples.len, samples.ptr);
+            var buffer_config = zaudio.AudioBuffer.Config.init(.float32, self.channels, samples.len / self.channels, samples.ptr);
             buffer_config.sample_rate = self.sample_rate;
             buffer_config.channels = self.channels;
             const buffer = try zaudio.AudioBuffer.create(buffer_config);

--- a/src/wave.zig
+++ b/src/wave.zig
@@ -581,7 +581,6 @@ pub fn inner(comptime T: type) type {
 
             var buffer_config = zaudio.AudioBuffer.Config.init(.float32, self.channels, samples.len / self.channels, samples.ptr);
             buffer_config.sample_rate = self.sample_rate;
-            buffer_config.channels = self.channels;
             const buffer = try zaudio.AudioBuffer.create(buffer_config);
             defer buffer.destroy();
             const sound = try engine.createSoundFromDataSource(buffer.asDataSourceMut(), .{}, null);


### PR DESCRIPTION
## Purpose

- Fixes a bug in lightmix when I use `Wave(T).play()` on Windows 10.

# Description

When I run `try Wave(T).play()` function in Windows 10, I encountered a segmentation fault

```
~\program-dir\github.com\haruki7049\rappa> ./zig-out/bin/a3-horn.zig.exe
Segmentation fault at address 0x1e866b0d000
C:\Users\tonto\AppData\Local\zig\p\zaudio-0.11.0-dev-_M-91kHvPwAlW8MCRI4XiTbTeihqB8Zspgiuw-6Gqgdz\libs\miniaudio\miniaudio.h:43052:0: 0x7ff69c151f98 in ma_copy_pcm_frames (miniaudio.lib)
    ma_copy_memory_64(dst, src, frameCount * ma_get_bytes_per_frame(format, channels));

C:\Users\tonto\AppData\Local\zig\p\zaudio-0.11.0-dev-_M-91kHvPwAlW8MCRI4XiTbTeihqB8Zspgiuw-6Gqgdz\libs\miniaudio\miniaudio.h:58846:0: 0x7ff69c17e93e in ma_audio_buffer_alloc_and_init (miniaudio.lib)
        ma_copy_pcm_frames(&pAudioBuffer->_pExtraData[0], pConfig->pData, pConfig->sizeInFrames, pConfig->format, pConfig->channels);

C:\Users\tonto\AppData\Local\zig\p\zaudio-0.11.0-dev-_M-91kHvPwAlW8MCRI4XiTbTeihqB8Zspgiuw-6Gqgdz\src\zaudio.c:626:0: 0x7ff69c145918 in zaudioAudioBufferCreate (miniaudio.lib)
    ma_result res = ma_audio_buffer_alloc_and_init(config, out_handle);

C:\Users\tonto\AppData\Local\zig\p\zaudio-0.11.0-dev-_M-91kHvPwAlW8MCRI4XiTbTeihqB8Zspgiuw-6Gqgdz\src\zaudio.zig:742:47: 0x7ff69c1336bb in create (a3-horn.zig_zcu.obj)
        try maybeError(zaudioAudioBufferCreate(&config, &handle));
                                              ^
C:\Users\tonto\AppData\Local\zig\p\lightmix-0.20.2-SpCovBCXAgAkjAMAeyBPqC3hGkfpBTFcebh2VIeZ-diS\src\wave.zig:585:57: 0x7ff69c13034a in play (a3-horn.zig_zcu.obj)
            const buffer = try zaudio.AudioBuffer.create(buffer_config);
                                                        ^
C:\Users\tonto\program-dir\github.com\haruki7049\rappa\examples\a3-horn.zig:33:18: 0x7ff69c12e1c1 in main (a3-horn.zig_zcu.obj)
    try wave.play();
                 ^
C:\Users\tonto\AppData\Local\Microsoft\WinGet\Packages\zig.zig_Microsoft.Winget.Source_8wekyb3d8bbwe\zig-x86_64-windows-0.15.2\lib\std\start.zig:602:28: 0x7ff69c13089d in main (a3-horn.zig_zcu.obj)
    return callMainWithArgs(@as(usize, @intCast(c_argc)), @as([*][*:0]u8, @ptrCast(c_argv)), envp);
                           ^
C:\Users\tonto\AppData\Local\Microsoft\WinGet\Packages\zig.zig_Microsoft.Winget.Source_8wekyb3d8bbwe\zig-x86_64-windows-0.15.2\lib\libc\mingw\crt\crtexe.c:259:0: 0x7ff69c140e2b in __tmainCRTStartup (crt2.obj)
    mainret = _tmain (argc, argv, envp);

C:\Users\tonto\AppData\Local\Microsoft\WinGet\Packages\zig.zig_Microsoft.Winget.Source_8wekyb3d8bbwe\zig-x86_64-windows-0.15.2\lib\libc\mingw\crt\crtexe.c:179:0: 0x7ff69c140e8b in mainCRTStartup (crt2.obj)
  ret = __tmainCRTStartup ();

???:?:?: 0x7ff87abf7373 in ??? (KERNEL32.DLL)
???:?:?: 0x7ff87c3dcc90 in ??? (ntdll.dll)
~\program-dir\github.com\haruki7049\rappa>  
```

The source code is [here](https://github.com/haruki7049/rappa/tree/667efb79402647701c294dc2ff7e218d2d5c260c).

https://github.com/haruki7049/rappa/tree/667efb79402647701c294dc2ff7e218d2d5c260c